### PR TITLE
CMakelists.txt: Stop using Make automatic variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,8 @@ set(CTR_VERSION_MINOR  5)
 set(CTR_VERSION_PATCH  6)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
-# Define __FILENAME__ consistently across Operating Systems
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
-else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
-endif()
+# Define __FILENAME__
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 
 # Configuration options
 option(CTR_DEV             "Enable development mode"                   No)


### PR DESCRIPTION
CMake Makefile layout generation has changed since version 3.20, ref: https://discourse.cmake.org/t/base-filename-gets-set-to-compiler-depend-ts-after-update-to-cmake-3-20/3075/4

For instance with Yocto framework this approach can lead to QA issue stemming from build host path ending up in generated binary like

  ERROR: fluentbit-3.1.9-r0 do_package_qa: QA Issue: File /usr/bin/fluent-bit in package fluentbit contains reference to TMPDIR [buildpaths]
  ERROR: fluentbit-3.1.9-r0 do_package_qa: Fatal QA errors were found, failing task.

stemming from

  $ strings packages-split/fluentbit/usr/bin/fluent-bit
  ...
  `$(subst /yocto/upstream/build/tmp/work/cortexa57-poky-linux/fluentbit/3.1.9/git/,,$(abspath $<))`
  ...